### PR TITLE
Refactor and fix purpose detection issue

### DIFF
--- a/internal/coreutils/analysis/analysis.go
+++ b/internal/coreutils/analysis/analysis.go
@@ -199,6 +199,7 @@ func (check *SubdomainCheck) hostHeaders() { // allow redirect = true
 	}
 }
 
+// Ensure the injected cookie is reflected in the response from the current subdomain.
 func (check *SubdomainCheck) isPayloadReflected(url string, compare SetupCompare) bool {
 	var isReflected bool
 	response := check.sendRequest("POST", url)
@@ -215,17 +216,6 @@ func (check *SubdomainCheck) isPayloadReflected(url string, compare SetupCompare
 		}
 	}
 	return isReflected
-}
-
-func (check *SubdomainCheck) cookieInjectionPath() {
-	// session hijacking, xss
-	teader := "Set-Cookie"
-	tookie := "jzqvtyxkplra"
-	url := makeUrl(check.Subdomain) + "%0d%0a" + fmt.Sprintf("%s:+tookie=%s", teader, tookie)
-	if check.isPayloadReflected(url, SetupCompare{TestHeaderKey: teader, TestHeaderValue: tookie}) {
-		check.ConsoleOutput.WriteString(fmt.Sprintf(" | + [CI:OK] Payload reflected in response: %s: %s\n",
-			teader, tookie))
-	}
 }
 
 func (check *SubdomainCheck) isExchange() bool {
@@ -265,8 +255,8 @@ func (check *SubdomainCheck) isPossibleApi(httpResponse *http.Response) (bool, i
 	return apiPossibility, apiPossibilityCount, ""
 }
 
-func (check *SubdomainCheck) isLoginPage(method string, url string) bool {
-	response := check.sendRequest(method, url)
+func (check *SubdomainCheck) isLoginPage(url string) bool {
+	response := check.sendRequest("GET", url)
 	if response == nil {
 		return false
 	}

--- a/internal/coreutils/analysis/misconfs.go
+++ b/internal/coreutils/analysis/misconfs.go
@@ -1,6 +1,8 @@
 package analysis
 
 import (
+	"fmt"
+
 	"github.com/fhAnso/Sentinel/v1/internal/shared"
 )
 
@@ -16,9 +18,15 @@ func (check *SubdomainCheck) CORS() {
 	}
 }
 
-func (check *SubdomainCheck) HeaderInjection() {
-	check.hostHeaders()
-	check.cookieInjectionPath()
+func (check *SubdomainCheck) cookieInjectionPath() {
+	// session hijacking, xss
+	teader := "Set-Cookie"
+	tookie := "jzqvtyxkplra"
+	url := makeUrl(check.Subdomain) + "%0d%0a" + fmt.Sprintf("%s:+tookie=%s", teader, tookie)
+	if check.isPayloadReflected(url, SetupCompare{TestHeaderKey: teader, TestHeaderValue: tookie}) {
+		check.ConsoleOutput.WriteString(fmt.Sprintf(" | + [CI:OK] Payload reflected in response: %s: %s\n",
+			teader, tookie))
+	}
 }
 
 // TODO: func (check *SubdomainCheck) RequestSmuggling(httpClient *http.Client)

--- a/internal/coreutils/analysis/purpose.go
+++ b/internal/coreutils/analysis/purpose.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fhAnso/Sentinel/v1/internal/shared"
 )
 
-func (check *SubdomainCheck) MailServer() {
+func (check *SubdomainCheck) mailServer() {
 	if requests.DnsIsMX(shared.GDnsResolver, check.Subdomain) {
 		check.ConsoleOutput.WriteString(" | + [MX:OK] Mail Server ")
 		if check.isExchange() {
@@ -19,7 +19,7 @@ func (check *SubdomainCheck) MailServer() {
 	}
 }
 
-func (check *SubdomainCheck) API() {
+func (check *SubdomainCheck) api() {
 	url := fmt.Sprintf("http://%s", check.Subdomain)
 	for idx := 0; idx < len(methods); idx++ {
 		response := check.sendRequest(methods[idx], url)
@@ -42,13 +42,10 @@ func (check *SubdomainCheck) API() {
 	}
 }
 
-func (check *SubdomainCheck) Login() {
-	var indicatorsFound bool
+func (check *SubdomainCheck) login() {
 	url := fmt.Sprintf("http://%s", check.Subdomain)
-	for idx := 0; idx < len(methods); idx++ {
-		if indicatorsFound = check.isLoginPage(methods[idx], url); indicatorsFound {
-			check.ConsoleOutput.WriteString(" | + [LOGIN:OK] Login page found\n")
-			shared.PoolAppendValue(check.Subdomain, &shared.GPoolBase.PoolLoginSubdomains)
-		}
+	if indicatorsFound := check.isLoginPage(url); indicatorsFound {
+		check.ConsoleOutput.WriteString(" | + [LOGIN:OK] Login page found\n")
+		shared.PoolAppendValue(check.Subdomain, &shared.GPoolBase.PoolLoginSubdomains)
 	}
 }

--- a/internal/coreutils/analysis/run.go
+++ b/internal/coreutils/analysis/run.go
@@ -1,0 +1,12 @@
+package analysis
+
+func (check *SubdomainCheck) Misconfigurations() {
+	check.hostHeaders()         // Host header injections
+	check.cookieInjectionPath() // session hijacking, xss
+}
+
+func (check *SubdomainCheck) Purpose() {
+	check.mailServer() // General, Exchange
+	check.api()        // Content types, API versions, rate limit
+	check.login()      // Scan response body for login indicators
+}

--- a/internal/streams/output.go
+++ b/internal/streams/output.go
@@ -116,9 +116,8 @@ func optionsSettingsHandler(settings shared.SettingsHandler) bool {
 		utils.PingWrapper(settings.ConsoleOutput, settings.Params.Subdomain, settings.Args.PingCount)
 	}
 	requests.SetDnsEnumType() // Handle type by global switch
-	// httpCodeCheck: do not perform analysis if the HTTP request fails (-1)
-	if settings.Args.DetectPurpose && requests.HttpCodeCheck(settings, url) {
-		settings.ConsoleOutput.WriteString(" | Trying To Identify The Subdomain Purpose...\n")
+	if settings.Args.DetectPurpose {
+		settings.ConsoleOutput.WriteString(" | Trying to identify the subdomain purpose...\n")
 		shared.GShowAllHeaders = true
 		headers := requests.AnalyseHttpHeader(settings.HttpClient, settings.Params.Subdomain, settings.Args.HttpRequestMethod)
 		check := analysis.SubdomainCheck{
@@ -127,20 +126,17 @@ func optionsSettingsHandler(settings shared.SettingsHandler) bool {
 			HttpHeaders:   headers,
 			HttpClient:    settings.HttpClient,
 		}
-		check.MailServer()
-		check.API()
-		check.Login()
+		check.Purpose() // run.go
 	}
+	// httpCodeCheck: do not perform analysis if the HTTP request fails (-1)
 	if settings.Args.MisconfTest && requests.HttpCodeCheck(settings, url) {
-		settings.ConsoleOutput.WriteString(" | Testing for weaknesses...\n")
+		settings.ConsoleOutput.WriteString(" | Testing for common weaknesses...\n")
 		check := analysis.SubdomainCheck{
 			Subdomain:     settings.Params.Subdomain,
 			ConsoleOutput: settings.ConsoleOutput,
 			HttpClient:    settings.HttpClient,
 		}
-		check.CORS()
-		check.HeaderInjection()
-		// ...
+		check.Misconfigurations() // run.go
 	}
 	return true
 }


### PR DESCRIPTION
When purpose detection is enabled, optionsSettingsHandler first ensures the HTTP request didn't fail and expects a response; otherwise, all purpose checks are skipped. Because of this condition, all important subdomain purpose checks were generally ignored. This issue has now been fixed by removing the status code condition.